### PR TITLE
Fix ECR permissions: change from ReadOnly to PowerUser policy for EKS…

### DIFF
--- a/modules/eks/eks.tf
+++ b/modules/eks/eks.tf
@@ -69,7 +69,7 @@ resource "aws_iam_role_policy_attachment" "eks_cni_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "eks_container_registry_policy" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
   role       = aws_iam_role.eks_node_group.name
 }
 


### PR DESCRIPTION
… node group

- Changed AmazonEC2ContainerRegistryReadOnly to AmazonEC2ContainerRegistryPowerUser
- This allows Jenkins Kaniko to push Docker images to ECR repository
- Fixes ECR permission error: ecr:InitiateLayerUpload action denied